### PR TITLE
Fix production build and use it on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "assets"
   ],
   "scripts": {
-    "prepublish": "npm prune && npm run build",
+    "prepublish": "npm prune && npm run build:prod",
     "build": "cross-env NODE_ENV=development webpack --config webpack.config.js",
     "build:prod": "cross-env NODE_ENV=production webpack --config webpack.config.js"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,6 @@ const baseConfig = {
 };
 
 switch (process.env.NODE_ENV) {
-  default:
   case 'development':
     module.exports = merge(baseConfig, {
       devtool: 'inline-source-map',
@@ -51,4 +50,6 @@ switch (process.env.NODE_ENV) {
       ],
     });
     break;
+  default:
+    module.exports = baseConfig;
 }


### PR DESCRIPTION
The development build was being used for prepublish, which depends on source-map-support, which is a development dependency and is not included with this module. This will cause an error because there's a missing module.

Also, previously both development and production build depended on source-map-support, now production build doesn't include source maps nor the module.


Let me know if I misunderstood your development setup. :+1: