### PR TITLE
Close the express server in the Launcher's onComplete method

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -17,7 +17,7 @@ export default class StaticServerLauncher {
       return Promise.resolve();
     }
 
-    this.server = express();
+    this.app = express();
     this.folders = folders;
     this.port = port;
 
@@ -29,22 +29,22 @@ export default class StaticServerLauncher {
         stream = fs.createWriteStream(file);
       }
       this.log = new Log('debug', stream);
-      this.server.use(morgan('tiny', { stream }));
+      this.app.use(morgan('tiny', { stream }));
     } else {
       this.log = new Log('emergency');
     }
 
     (Array.isArray(folders) ? folders : [ folders ]).forEach((folder) => {
       this.log.debug('Mounting folder `%s` at `%s`', path.resolve(folder.path), folder.mount);
-      this.server.use(folder.mount, express.static(folder.path));
+      this.app.use(folder.mount, express.static(folder.path));
     });
 
     middleware.forEach((ware) => {
-      this.server.use(ware.mount, ware.middleware);
+      this.app.use(ware.mount, ware.middleware);
     });
 
     return new Promise((resolve, reject) => {
-      this.server.listen(this.port, (err) => {
+      this.server = this.app.listen(this.port, (err) => {
         if (err) {
           reject(err);
         }
@@ -54,5 +54,9 @@ export default class StaticServerLauncher {
       });
     });
   }
-
+  onComplete() {
+    if (this.server) {
+      this.server.close();
+    }
+  }
 }


### PR DESCRIPTION
Used in conjunction with gulp-webdriver, the failure to close the server socket causes the gulp process to hang indefinitely.