### PR TITLE
Change order of registering middleware and mounting folders.

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -34,13 +34,13 @@ export default class StaticServerLauncher {
       this.log = new Log('emergency');
     }
 
+    middleware.forEach((ware) => {
+      this.server.use(ware.mount, ware.middleware);
+    });
+
     (Array.isArray(folders) ? folders : [ folders ]).forEach((folder) => {
       this.log.debug('Mounting folder `%s` at `%s`', path.resolve(folder.path), folder.mount);
       this.server.use(folder.mount, express.static(folder.path));
-    });
-
-    middleware.forEach((ware) => {
-      this.server.use(ware.mount, ware.middleware);
     });
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
#Problem
* Registering of middleware was already implemented, but did not work properly.
* Setting the CORS middleware didn't work because of this.

#Solution
* Change order of mounting files and registering middleware, since the middleware is not applied to files that have been mounted before the middleware is registered.